### PR TITLE
Fix: User Page Styling

### DIFF
--- a/src/components/packages/PackageItem.js
+++ b/src/components/packages/PackageItem.js
@@ -41,7 +41,11 @@ const Package = styled.div`
   .package-item__header-info {
     display: flex;
     justify-content: space-between;
-    padding: 2rem;
+    padding: 2rem 1.5rem;
+
+    @media all and (min-width: 768px) {
+      padding: 2rem;
+    }
   }
 
   .package-item__name {

--- a/src/components/site-header/SiteHeader.js
+++ b/src/components/site-header/SiteHeader.js
@@ -23,7 +23,7 @@ const Header = styled.header`
     flex-direction: column;
     justify-content: center;
     text-decoration: none;
-    padding: 1rem;
+    padding: 1rem 1.5rem;
     background-color: var(--color-white);
     color: var(--color-black);
     height: 6rem;
@@ -74,7 +74,7 @@ const InfoButton = styled.button`
   width: 2.5rem;
   height: 2.5rem;
   margin-left: 1rem;
-  margin-right: 1rem;
+  margin-right: 1.5rem;
   border-radius: 50%;
   transition: background-color 0.2s ease-in-out;
 

--- a/src/components/users/UserInfo.js
+++ b/src/components/users/UserInfo.js
@@ -12,7 +12,7 @@ const Wrapper = styled.section`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 1rem;
+  padding: 1rem 1.5rem;
 
   .user__info {
     display: flex;

--- a/src/pages/user.js
+++ b/src/pages/user.js
@@ -85,7 +85,7 @@ class User extends Component {
     } = this.props;
 
     return (
-      <ViewWrapper className="app-view app-view--user" packages={packages}>
+      <ViewWrapper className={`app-view app-view--user ${user && 'app-view--user--active'}`} packages={packages}>
         <Head>
           <title>{`${router.query.username}’s packages on Pkg Stats - npm package discovery and stats viewer.`}</title>
           <meta name="description" key="description" content={`Explore ${router.query.username}’s packages on Pkg Stats - npm package discovery and stats viewer.`} />

--- a/src/styles/global/base.js
+++ b/src/styles/global/base.js
@@ -60,7 +60,7 @@ const base = `
     margin-top: 6rem;
   }
 
-  .app-view--user {
+  .app-view--user--active {
     margin-top: 13rem;
   }
 


### PR DESCRIPTION
* Remove `margin` from `user` page if `user` info is not available to display
* Update `padding`/`margin`s to be consistent between components on mobile